### PR TITLE
Modify object in 6.7.8 profiles

### DIFF
--- a/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t03.xml
+++ b/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t03.xml
@@ -6,7 +6,7 @@
     <created>2015-06-29T09:25:21Z</created>
     <hash>sha-1 hash code</hash>
     <rules>
-		<rule id="6-7-8-t03" object="XMPCustomSchema">
+		<rule id="6-7-8-t03" object="PBPDFAExtensionSchema">
 			<description>The required PDF/A Extension Schema namespace prefix is pdfaExtension.</description>
 			<test>prefix == "pdfaExtension"</test>
 			<error>

--- a/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t04.xml
+++ b/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t04.xml
@@ -6,7 +6,7 @@
     <created>2015-06-29T09:27:41Z</created>
     <hash>sha-1 hash code</hash>
     <rules>
-		<rule id="6-7-8-t04" object="XMPCustomSchema">
+		<rule id="6-7-8-t04" object="PBPDFAExtensionSchema">
 			<description>A PDF/A Field Schema namespace prefix is required to be "pdfaField".</description>
 			<test>isPDFAFieldPrefixCorrect</test>
 			<error>

--- a/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t05.xml
+++ b/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t05.xml
@@ -6,7 +6,7 @@
     <created>2015-06-29T09:36:41Z</created>
     <hash>sha-1 hash code</hash>
     <rules>
-		<rule id="6-7-8-t05" object="XMPCustomSchema">
+		<rule id="6-7-8-t05" object="PBPDFAExtensionSchema">
 			<description>A PDF/A Property Schema namespace prefix is required to be "pdfaProperty".</description>
 			<test>isPDFAPropertyPrefixCorrect</test>
 			<error>

--- a/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t06.xml
+++ b/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t06.xml
@@ -6,7 +6,7 @@
     <created>2015-06-29T09:38:41Z</created>
     <hash>sha-1 hash code</hash>
     <rules>
-		<rule id="6-7-8-t06" object="XMPCustomSchema">
+		<rule id="6-7-8-t06" object="PBPDFAExtensionSchema">
 			<description>A PDF/A Schema Description Schema namespace prefix is required to be "pdfaSchema".</description>
 			<test>isPDFASchemaPrefixCorrect</test>
 			<error>

--- a/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t07.xml
+++ b/PDF_A/1b/6.7 Metadata/6.7.8/verapdf-profile-6-7-8-t07.xml
@@ -6,7 +6,7 @@
     <created>2015-06-29T09:39:41Z</created>
     <hash>sha-1 hash code</hash>
     <rules>
-		<rule id="6-7-8-t07" object="XMPCustomSchema">
+		<rule id="6-7-8-t07" object="PBPDFAExtensionSchema">
 			<description>A PDF/A ValueType Schema namespace prefix is required to be "pdfaType".</description>
 			<test>isPDFATypePrefixCorrect</test>
 			<error>


### PR DESCRIPTION
Change "XMPCustomSchema" value  to "PBPDFAExtensionSchema" in object for the following profiles:
* verapdf-profile-6-7-8-t03
* verapdf-profile-6-7-8-t04
* verapdf-profile-6-7-8-t05
* verapdf-profile-6-7-8-t06
* verapdf-profile-6-7-8-t07