### PR TITLE
Added validation profile for DeviceGray color spaces

### DIFF
--- a/PDF_A/1b/6.2 Graphics/6.2.3 Colour spaces/verapdf-profile-6-2-3-t02.xml
+++ b/PDF_A/1b/6.2 Graphics/6.2.3 Colour spaces/verapdf-profile-6-2-3-t02.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" model="org.verapdf.model.PDFA1a">
     <name>ISO 19005-1:2005 - 6.2.3 Colour Spaces - 6.2.3.3 Uncalibrated colour spaces - DeviceRGB</name>
-    <description>If an uncalibrated colour space is used in a file then that file shall contain a PDF/A-1 OutputIntent, as defined in
-	6.2.2. DeviceRGB may be used only if the file has a PDF/A-1 OutputIntent that uses an RGB colour space</description>
+    <description>DeviceRGB may be used only if the file has a PDF/A-1 OutputIntent that uses an RGB colour space</description>
     <creator>veraPDF Consortium</creator>
     <created>2015-06-15T22:46:23Z</created>
     <hash>sha-1 hash code</hash>
     <rules>
 		<rule id="6-2-3-t02" object="PDDeviceRGB">
-			<description>If an uncalibrated colour space is used in a file then that file shall contain a PDF/A-1 OutputIntent, as defined in
-			6.2.2. DeviceRGB may be used only if the file has a PDF/A-1 OutputIntent that uses an RGB colour space</description>
+			<description>DeviceRGB may be used only if the file has a PDF/A-1 OutputIntent that uses an RGB colour space</description>
 			<test>gOutputCS != null &amp;&amp; gOutputCS == "RGB "</test>
 			<error>
 				<message>DeviceRGB colour space is used without RGB output intent profile</message>

--- a/PDF_A/1b/6.2 Graphics/6.2.3 Colour spaces/verapdf-profile-6-2-3-t03.xml
+++ b/PDF_A/1b/6.2 Graphics/6.2.3 Colour spaces/verapdf-profile-6-2-3-t03.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" model="org.verapdf.model.PDFA1a">
     <name>ISO 19005-1:2005 - 6.2.3 Colour Spaces - 6.2.3.3 Uncalibrated colour spaces - DeviceRGB</name>
-    <description>If an uncalibrated colour space is used in a file then that file shall contain a PDF/A-1 OutputIntent, as defined in
-	6.2.2. DeviceCMYK may be used only if the file has a PDF/A-1 OutputIntent that uses a CMYK colour space</description>
+    <description>DeviceCMYK may be used only if the file has a PDF/A-1 OutputIntent that uses a CMYK colour space</description>
     <creator>veraPDF Consortium</creator>
     <created>2015-06-15T22:46:23Z</created>
     <hash>sha-1 hash code</hash>
     <rules>
 		<rule id="6-2-3-t03" object="PDDeviceCMYK">
-			<description>If an uncalibrated colour space is used in a file then that file shall contain a PDF/A-1 OutputIntent, as defined in
-			6.2.2. DeviceCMYK may be used only if the file has a PDF/A-1 OutputIntent that uses a CMYK colour space</description>
+			<description>DeviceCMYK may be used only if the file has a PDF/A-1 OutputIntent that uses a CMYK colour space</description>
 			<test>gOutputCS != null &amp;&amp; gOutputCS == "CMYK"</test>
 			<error>
 				<message>DeviceCMYK colour space is used without CMYK output intent profile</message>

--- a/PDF_A/1b/6.2 Graphics/6.2.3 Colour spaces/verapdf-profile-6-2-3-t04.xml
+++ b/PDF_A/1b/6.2 Graphics/6.2.3 Colour spaces/verapdf-profile-6-2-3-t04.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" model="org.verapdf.model.PDFA1a">
+    <name>ISO 19005-1:2005 - 6.2.3 Colour Spaces - 6.2.3.3 Uncalibrated colour spaces - DeviceGray</name>
+    <description>If an uncalibrated colour space is used in a file then that file shall contain a PDF/A-1 OutputIntent, as defined in 6.2.2</description>
+    <creator>veraPDF Consortium</creator>
+    <created>2015-07-14T17:24:18Z</created>
+    <hash>sha-1 hash code</hash>
+    <rules>
+		<rule id="6-2-3-t04" object="PDDeviceGray">
+			<description>If an uncalibrated colour space is used in a file then that file shall contain a PDF/A-1 OutputIntent, as defined in 6.2.2</description>
+			<test>gOutputCS != null</test>
+			<error>
+				<message>DeviceGray colour space is used without output intent profile</message>
+			</error>
+			<reference>
+				<specification>ISO19005-1</specification>
+				<clause>6.2.3.3</clause>
+			</reference>
+		</rule>
+	</rules>
+	<variables>
+		<variable name="gOutputCS" object="ICCOutputProfile">
+			<defaultValue>null</defaultValue>
+			<value>S == "GTS_PDFA1" ? colorSpace : gOutputCS</value>
+		</variable>
+	</variables>
+</profile>


### PR DESCRIPTION
DeviceGray color spaces can be used only if the output ICC profile is
present (CMYK- or -RGB-based)