### PR TITLE
Removed pdfaid:corr property from the PDF/A Identification schema for PDF/A-1

### DIFF
--- a/PDF_A/1b/6.7 Metadata/6.7.11 Version and conformance level identification/verapdf-profile-6-7-11-t04.xml
+++ b/PDF_A/1b/6.7 Metadata/6.7.11 Version and conformance level identification/verapdf-profile-6-7-11-t04.xml
@@ -12,10 +12,9 @@
             <id specification="ISO_19005_1" clause="6.7.11" testNumber="4"/>
             <description>The PDF/A Identification schema defined in Table 8 uses the namespace URI &quot;http://www.aiim.org/pdfa/ns/id/&quot;. 
 			The required schema namespace prefix is pdfaid. It contains the following fields: pdfaid:part (Open Choice of Integer), 
-			pdfaid:amd (Open Choice of Text), pdfaid:corr (Open Choice of Text), pdfaid:conformance (Open Choice of Text)</description>
+			pdfaid:amd (Open Choice of Text), pdfaid:conformance (Open Choice of Text)</description>
             <test>partPrefix == &quot;pdfaid&quot; &amp;&amp; conformancePrefix == &quot;pdfaid&quot; &amp;&amp;
-			(amdPrefix == null || amdPrefix == &quot;pdfaid&quot;) &amp;&amp;
-			(corrPrefix == null || corrPrefix == &quot;pdfaid&quot;)</test>
+			(amdPrefix == null || amdPrefix == &quot;pdfaid&quot;)</test>
             <error>
                 <message>A property of the PDF/A Identification Schema has an invalid namespace prefix</message>
                 <arguments/>

--- a/PDF_A/PDFA-1A.xml
+++ b/PDF_A/PDFA-1A.xml
@@ -1156,10 +1156,9 @@
             <id specification="ISO_19005_1" clause="6.7.11" testNumber="4"/>
             <description>The PDF/A Identification schema defined in Table 8 uses the namespace URI &quot;http://www.aiim.org/pdfa/ns/id/&quot;. 
 			The required schema namespace prefix is pdfaid. It contains the following fields: pdfaid:part (Open Choice of Integer), 
-			pdfaid:amd (Open Choice of Text), pdfaid:corr (Open Choice of Text), pdfaid:conformance (Open Choice of Text)</description>
+			pdfaid:amd (Open Choice of Text), pdfaid:conformance (Open Choice of Text)</description>
             <test>partPrefix == &quot;pdfaid&quot; &amp;&amp; conformancePrefix == &quot;pdfaid&quot; &amp;&amp;
-			(amdPrefix == null || amdPrefix == &quot;pdfaid&quot;) &amp;&amp;
-			(corrPrefix == null || corrPrefix == &quot;pdfaid&quot;)</test>
+			(amdPrefix == null || amdPrefix == &quot;pdfaid&quot;)</test>
             <error>
                 <message>A property of the PDF/A Identification Schema has an invalid namespace prefix</message>
                 <arguments/>

--- a/PDF_A/PDFA-1B.xml
+++ b/PDF_A/PDFA-1B.xml
@@ -1156,10 +1156,9 @@
             <id specification="ISO_19005_1" clause="6.7.11" testNumber="4"/>
             <description>The PDF/A Identification schema defined in Table 8 uses the namespace URI &quot;http://www.aiim.org/pdfa/ns/id/&quot;. 
 			The required schema namespace prefix is pdfaid. It contains the following fields: pdfaid:part (Open Choice of Integer), 
-			pdfaid:amd (Open Choice of Text), pdfaid:corr (Open Choice of Text), pdfaid:conformance (Open Choice of Text)</description>
+			pdfaid:amd (Open Choice of Text), pdfaid:conformance (Open Choice of Text)</description>
             <test>partPrefix == &quot;pdfaid&quot; &amp;&amp; conformancePrefix == &quot;pdfaid&quot; &amp;&amp;
-			(amdPrefix == null || amdPrefix == &quot;pdfaid&quot;) &amp;&amp;
-			(corrPrefix == null || corrPrefix == &quot;pdfaid&quot;)</test>
+			(amdPrefix == null || amdPrefix == &quot;pdfaid&quot;)</test>
             <error>
                 <message>A property of the PDF/A Identification Schema has an invalid namespace prefix</message>
                 <arguments/>


### PR DESCRIPTION
The pdfaid:corr property (Corrigendum) is not defined for PDF/A-1, but
is a valid property in the PDF/A Identification schema for PDF/A-2 and
PDF/A-3