### PR TITLE
Added extra requirements into PDF/A-2 and PDF/A-3 profiles

### DIFF
--- a/PDF_A/1b/6.5 Annotations/6.5.3 Annotation dictionaries/verapdf-profile-6-5-3-t04.xml
+++ b/PDF_A/1b/6.5 Annotations/6.5.3 Annotation dictionaries/verapdf-profile-6-5-3-t04.xml
@@ -11,9 +11,10 @@
         <rule object="PDAnnot">
             <id specification="ISO_19005_1" clause="6.5.3" testNumber="4"/>
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall contain only the N key. 
-			If an annotation dictionary’s Subtype key has a value of Widget and its FT key has a value of Btn, the value of the N key shall be an appearance 
+			If an annotation dictionary's Subtype key has a value of Widget and its FT key has a value of Btn, the value of the N key shall be an appearance 
 			subdictionary; otherwise the value of the N key shall be an appearance stream.</description>
-            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( N_type == &quot;Stream&quot; || (FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
+            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( ((Subtype != &quot;Widget&quot; || FT != &quot;Btn&quot;) &amp;&amp; N_type == &quot;Stream&quot;)
+			|| (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
             <error>
                 <message>Annotation's appearance dictionary contains entries other than N or the N entry has an invalid type</message>
                 <arguments/>

--- a/PDF_A/2b/6.10 Use of alternate presentations and transitions/verapdf-profile-6-10-t01.xml
+++ b/PDF_A/2b/6.10 Use of alternate presentations and transitions/verapdf-profile-6-10-t01.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_2_B">
+    <details creator="veraPDF Consortium" created="2016-02-27T13:01:08.799+03:00">
+        <name>ISO 19005-2:2011 - 6.10 Use of alternate presentations and transitions - AlternatePresentations</name>
+        <description>There shall be no AlternatePresentations entry in the document's name dictionary</description>
+    </details>
+    <hash></hash>
+    <rules>
+		<rule object="PDDocument">
+            <id specification="ISO_19005_2" clause="6.10" testNumber="1"/>
+            <description>There shall be no AlternatePresentations entry in the document's name dictionary</description>
+            <test>AlternatePresentations_size == 0</test>
+            <error>
+                <message>The document's name dictionary contains the AlternatePresentations entry</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>
+    </rules>
+    <variables/>
+</profile>

--- a/PDF_A/2b/6.10 Use of alternate presentations and transitions/verapdf-profile-6-10-t02.xml
+++ b/PDF_A/2b/6.10 Use of alternate presentations and transitions/verapdf-profile-6-10-t02.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_2_B">
+    <details creator="veraPDF Consortium" created="2016-02-27T13:05:32.541+03:00">
+        <name>ISO 19005-2:2011 - 6.10 Use of alternate presentations and transitions - PresSteps</name>
+        <description>There shall be no PresSteps entry in any Page dictionary</description>
+    </details>
+    <hash></hash>
+    <rules>
+		<rule object="PDPage">
+            <id specification="ISO_19005_2" clause="6.10" testNumber="2"/>
+            <description>There shall be no PresSteps entry in any Page dictionary</description>
+            <test>PresSteps_size == 0</test>
+            <error>
+                <message>A Page dictionary contains the PresSteps entry</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>
+    </rules>
+    <variables/>
+</profile>

--- a/PDF_A/2b/6.11 Document requirements/verapdf-profile-6-11-t01.xml
+++ b/PDF_A/2b/6.11 Document requirements/verapdf-profile-6-11-t01.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_2_B">
+    <details creator="veraPDF Consortium" created="2016-02-27T13:05:32.541+03:00">
+        <name>ISO 19005-2:2011 - 6.11 Document requirements</name>
+        <description>The document catalog shall not contain the Requirements key</description>
+    </details>
+    <hash></hash>
+    <rules>
+		<rule object="CosDocument">
+            <id specification="ISO_19005_2" clause="6.11" testNumber="1"/>
+            <description>The document catalog shall not contain the Requirements key</description>
+            <test>Requirements_size == 0</test>
+            <error>
+                <message>The document catalog contains the Requirements key</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>
+    </rules>
+    <variables/>
+</profile>

--- a/PDF_A/2b/6.3 Annotations/6.3.3 Annotation appearances/verapdf-profile-6-3-3-t02.xml
+++ b/PDF_A/2b/6.3 Annotations/6.3.3 Annotation appearances/verapdf-profile-6-3-3-t02.xml
@@ -9,11 +9,12 @@
     <hash></hash>
     <rules>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.3" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.3.3" testNumber="2"/>
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall
 			contain only the N key. If an annotation dictionary's Subtype key has a value of Widget and its FT key has a
 			value of Btn, the value of the N key shall be an appearance subdictionary, otherwise the value of the N key shall be an appearance stream.</description>
-            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( N_type == &quot;Stream&quot; || (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
+            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( ((Subtype != &quot;Widget&quot; || FT != &quot;Btn&quot;) &amp;&amp; N_type == &quot;Stream&quot;)
+			|| (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
             <error>
                 <message>Annotation's appearance dictionary contains entries other than N or the N entry has an invalid type</message>
                 <arguments/>

--- a/PDF_A/PDFA-1A.xml
+++ b/PDF_A/PDFA-1A.xml
@@ -875,7 +875,8 @@
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall contain only the N key. 
 			If an annotation dictionary’s Subtype key has a value of Widget and its FT key has a value of Btn, the value of the N key shall be an appearance 
 			subdictionary; otherwise the value of the N key shall be an appearance stream.</description>
-            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( N_type == &quot;Stream&quot; || (FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
+            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( ((Subtype != &quot;Widget&quot; || FT != &quot;Btn&quot;) &amp;&amp; N_type == &quot;Stream&quot;)
+			|| (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
             <error>
                 <message>Annotation's appearance dictionary contains entries other than N or the N entry has an invalid type</message>
                 <arguments/>

--- a/PDF_A/PDFA-1B.xml
+++ b/PDF_A/PDFA-1B.xml
@@ -875,8 +875,9 @@
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall contain only the N key. 
 			If an annotation dictionary’s Subtype key has a value of Widget and its FT key has a value of Btn, the value of the N key shall be an appearance 
 			subdictionary; otherwise the value of the N key shall be an appearance stream.</description>
-            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( N_type == &quot;Stream&quot; || (FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
-            <error>
+            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( ((Subtype != &quot;Widget&quot; || FT != &quot;Btn&quot;) &amp;&amp; N_type == &quot;Stream&quot;)
+			|| (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
+			<error>
                 <message>Annotation's appearance dictionary contains entries other than N or the N entry has an invalid type</message>
                 <arguments/>
             </error>

--- a/PDF_A/PDFA-2B.xml
+++ b/PDF_A/PDFA-2B.xml
@@ -859,7 +859,8 @@
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall
 			contain only the N key. If an annotation dictionary's Subtype key has a value of Widget and its FT key has a
 			value of Btn, the value of the N key shall be an appearance subdictionary, otherwise the value of the N key shall be an appearance stream.</description>
-            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( N_type == &quot;Stream&quot; || (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
+            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( ((Subtype != &quot;Widget&quot; || FT != &quot;Btn&quot;) &amp;&amp; N_type == &quot;Stream&quot;)
+			|| (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
             <error>
                 <message>Annotation's appearance dictionary contains entries other than N or the N entry has an invalid type</message>
                 <arguments/>
@@ -1179,6 +1180,36 @@
             </error>
             <references/>
         </rule>
+		<rule object="PDDocument">
+            <id specification="ISO_19005_2" clause="6.10" testNumber="1"/>
+            <description>There shall be no AlternatePresentations entry in the document's name dictionary</description>
+            <test>AlternatePresentations_size == 0</test>
+            <error>
+                <message>The document's name dictionary contains the AlternatePresentations entry</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>
+		<rule object="PDPage">
+            <id specification="ISO_19005_2" clause="6.10" testNumber="2"/>
+            <description>There shall be no PresSteps entry in any Page dictionary</description>
+            <test>PresSteps_size == 0</test>
+            <error>
+                <message>A Page dictionary contains the PresSteps entry</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>		
+		<rule object="CosDocument">
+            <id specification="ISO_19005_2" clause="6.11" testNumber="1"/>
+            <description>The document catalog shall not contain the Requirements key</description>
+            <test>Requirements_size == 0</test>
+            <error>
+                <message>The document catalog contains the Requirements key</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>		
     </rules>
     <variables>
         <variable name="gOutputCS" object="ICCOutputProfile">

--- a/PDF_A/PDFA-3B.xml
+++ b/PDF_A/PDFA-3B.xml
@@ -855,7 +855,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_2" clause="6.3.3" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.3.3" testNumber="2"/>
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall
 			contain only the N key. If an annotation dictionary's Subtype key has a value of Widget and its FT key has a
 			value of Btn, the value of the N key shall be an appearance subdictionary, otherwise the value of the N key shall be an appearance stream.</description>

--- a/PDF_A/PDFA-3B.xml
+++ b/PDF_A/PDFA-3B.xml
@@ -855,11 +855,12 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_3" clause="6.3.3" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.3.3" testNumber="2"/>
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall
 			contain only the N key. If an annotation dictionary's Subtype key has a value of Widget and its FT key has a
 			value of Btn, the value of the N key shall be an appearance subdictionary, otherwise the value of the N key shall be an appearance stream.</description>
-            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( N_type == &quot;Stream&quot; || (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
+            <test>AP == null || ( AP == &quot;N&quot; &amp;&amp; ( ((Subtype != &quot;Widget&quot; || FT != &quot;Btn&quot;) &amp;&amp; N_type == &quot;Stream&quot;)
+			|| (Subtype == &quot;Widget&quot; &amp;&amp; FT == &quot;Btn&quot; &amp;&amp; N_type == &quot;Dict&quot;) ) )</test>
             <error>
                 <message>Annotation's appearance dictionary contains entries other than N or the N entry has an invalid type</message>
                 <arguments/>
@@ -1190,6 +1191,36 @@
             </error>
             <references/>
         </rule>
+		<rule object="PDPage">
+            <id specification="ISO_19005_2" clause="6.10" testNumber="2"/>
+            <description>There shall be no PresSteps entry in any Page dictionary</description>
+            <test>PresSteps_size == 0</test>
+            <error>
+                <message>A Page dictionary contains the PresSteps entry</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>		
+		<rule object="CosDocument">
+            <id specification="ISO_19005_2" clause="6.11" testNumber="1"/>
+            <description>The document catalog shall not contain the Requirements key</description>
+            <test>Requirements_size == 0</test>
+            <error>
+                <message>The document catalog contains the Requirements key</message>
+                <arguments/>
+            </error>
+            <references/>
+        </rule>		
+    </rules>
+    <variables>
+        <variable name="gOutputCS" object="ICCOutputProfile">
+            <defaultValue>null</defaultValue>
+            <value>S == &quot;GTS_PDFA1&quot; ? colorSpace : gOutputCS</value>
+        </variable>
+        <variable name="gOutputProfileIndirect" object="PDOutputIntent">
+            <defaultValue>null</defaultValue>
+            <value>gOutputProfileIndirect== null ? destOutputProfileIndirect : gOutputProfileIndirect</value>
+        </variable>		
     </rules>
     <variables>
         <variable name="gOutputCS" object="ICCOutputProfile">


### PR DESCRIPTION
Added new rules for PDF/A-2 and PDF/A-3:

- 6.10 Use of alternate presentations and transitions -
AlternatePresentations
- 6.10 Use of alternate presentations and transitions - PresSteps
- 6.11 Document requirements

Updated the requirement for the Annotation's normal appearance type (all PDF/A levels): 
- According to the TWG discussions we do require now that the normal appearance is of type dictionary for all Button fields, even if they have a single state