### PR TITLE
Fixed the rule to check the implementation limits for CIDs

### DIFF
--- a/PDF_A/2b/6.1 File structure/6.1.13 Implementation limits/verapdf-profile-6-1-13-t10.xml
+++ b/PDF_A/2b/6.1 File structure/6.1.13 Implementation limits/verapdf-profile-6-1-13-t10.xml
@@ -6,10 +6,10 @@
     </details>
     <hash></hash>
     <rules>
-        <rule object="CIDGlyph">
+        <rule object="CMapFile">
             <id specification="ISO_19005_1" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
-            <test>CID &lt;= 65535</test>
+            <test>maximalCID &lt;= 65535</test>
             <error>
                 <message>Maximum value of a CID (65535) is exceeded</message>
                 <arguments/>

--- a/PDF_A/PDFA-2A.xml
+++ b/PDF_A/PDFA-2A.xml
@@ -291,10 +291,10 @@
             </error>
             <references/>
         </rule>
-        <rule object="CIDGlyph">
+        <rule object="CMapFile">
             <id specification="ISO_19005_2" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
-            <test>CID &lt;= 65535</test>
+            <test>maximalCID &lt;= 65535</test>
             <error>
                 <message>Maximum value of a CID (65535) is exceeded</message>
                 <arguments/>

--- a/PDF_A/PDFA-2B.xml
+++ b/PDF_A/PDFA-2B.xml
@@ -291,10 +291,10 @@
             </error>
             <references/>
         </rule>
-        <rule object="CIDGlyph">
+        <rule object="CMapFile">
             <id specification="ISO_19005_2" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
-            <test>CID &lt;= 65535</test>
+            <test>maximalCID &lt;= 65535</test>
             <error>
                 <message>Maximum value of a CID (65535) is exceeded</message>
                 <arguments/>

--- a/PDF_A/PDFA-2U.xml
+++ b/PDF_A/PDFA-2U.xml
@@ -291,10 +291,10 @@
             </error>
             <references/>
         </rule>
-        <rule object="CIDGlyph">
+        <rule object="CMapFile">
             <id specification="ISO_19005_2" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
-            <test>CID &lt;= 65535</test>
+            <test>maximalCID &lt;= 65535</test>
             <error>
                 <message>Maximum value of a CID (65535) is exceeded</message>
                 <arguments/>

--- a/PDF_A/PDFA-3A.xml
+++ b/PDF_A/PDFA-3A.xml
@@ -291,10 +291,10 @@
             </error>
             <references/>
         </rule>
-        <rule object="CIDGlyph">
+        <rule object="CMapFile">
             <id specification="ISO_19005_3" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
-            <test>CID &lt;= 65535</test>
+            <test>maximalCID &lt;= 65535</test>
             <error>
                 <message>Maximum value of a CID (65535) is exceeded</message>
                 <arguments/>

--- a/PDF_A/PDFA-3B.xml
+++ b/PDF_A/PDFA-3B.xml
@@ -291,10 +291,10 @@
             </error>
             <references/>
         </rule>
-        <rule object="CIDGlyph">
+        <rule object="CMapFile">
             <id specification="ISO_19005_3" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
-            <test>CID &lt;= 65535</test>
+            <test>maximalCID &lt;= 65535</test>
             <error>
                 <message>Maximum value of a CID (65535) is exceeded</message>
                 <arguments/>

--- a/PDF_A/PDFA-3U.xml
+++ b/PDF_A/PDFA-3U.xml
@@ -291,10 +291,10 @@
             </error>
             <references/>
         </rule>
-        <rule object="CIDGlyph">
+        <rule object="CMapFile">
             <id specification="ISO_19005_3" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
-            <test>CID &lt;= 65535</test>
+            <test>maximalCID &lt;= 65535</test>
             <error>
                 <message>Maximum value of a CID (65535) is exceeded</message>
                 <arguments/>


### PR DESCRIPTION
It now checks not only CIDs of the glyphs used on the page, but also CIDs present in the CMap.