### PR TITLE
PDF/A validation. Add rule about BitsPerComponent

### DIFF
--- a/PDF_A/1b/6.2 Graphics/6.2.4 Images/verapdf-profile-6-2-4-t04.xml
+++ b/PDF_A/1b/6.2 Graphics/6.2.4 Images/verapdf-profile-6-2-4-t04.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_1_A">
+    <details creator="veraPDF Consortium" created="2023-07-10T10:58:05.420+03:00">
+        <name>ISO 19005-1:2005 - 6.2.4 Images - BitsPerComponent</name>
+        <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4 or 8</description>
+    </details>
+    <hash></hash>
+    <rules>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_1" clause="6.2.4" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4 or 8</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="PDF 1.4 Reference" clause="4.8.4, Table 4.35"/>
+            </references>
+        </rule>
+    </rules>
+    <variables/>
+</profile>

--- a/PDF_A/2b/6.2 Graphics/6.2.8 Images/6.2.8.1 General/verapdf-profile-6-2-8-t04.xml
+++ b/PDF_A/2b/6.2 Graphics/6.2.8 Images/6.2.8.1 General/verapdf-profile-6-2-8-t04.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_2_B">
+    <details creator="veraPDF Consortium" created="2023-07-10T10:58:05.420+03:00">
+        <name>ISO 19005-2:2011 - 6.2.8 Images - BitsPerComponent</name>
+        <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+    </details>
+    <hash></hash>
+    <rules>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_2" clause="6.2.8" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-1:2008" clause="8.9.5.1, Table 89"/>
+            </references>
+        </rule>
+    </rules>
+    <variables/>
+</profile>

--- a/PDF_A/4/6.2 Graphics/6.2.7 Images/6.2.7.1 General/verapdf-profile-6-2-7-1-t04.xml
+++ b/PDF_A/4/6.2 Graphics/6.2.7 Images/6.2.7.1 General/verapdf-profile-6-2-7-1-t04.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_4">
+    <details creator="veraPDF Consortium" created="2023-07-10T10:58:05.420+03:00">
+        <name>ISO 19005-4:2020 - 6.2.7 Images - BitsPerComponent</name>
+        <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+    </details>
+    <hash></hash>
+    <rules>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_4" clause="6.2.7.1" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-2:2020" clause="8.9.5.1, Table 87"/>
+            </references>
+        </rule>
+    </rules>
+    <variables/>
+</profile>

--- a/PDF_A/PDFA-1A.xml
+++ b/PDF_A/PDFA-1A.xml
@@ -497,6 +497,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_1" clause="6.2.4" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4 or 8</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="PDF 1.4 Reference" clause="4.8.4, Table 4.35"/>
+            </references>
+        </rule>
         <rule object="PDXForm">
             <id specification="ISO_19005_1" clause="6.2.5" testNumber="1"/>
             <description>A form XObject dictionary shall not contain the Subtype2 key with a value of PS or the PS key</description>

--- a/PDF_A/PDFA-1B.xml
+++ b/PDF_A/PDFA-1B.xml
@@ -497,6 +497,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_1" clause="6.2.4" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4 or 8</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="PDF 1.4 Reference" clause="4.8.4, Table 4.35"/>
+            </references>
+        </rule>
         <rule object="PDXForm">
             <id specification="ISO_19005_1" clause="6.2.5" testNumber="1"/>
             <description>A form XObject dictionary shall not contain the Subtype2 key with a value of PS or the PS key</description>

--- a/PDF_A/PDFA-2A.xml
+++ b/PDF_A/PDFA-2A.xml
@@ -639,6 +639,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_2" clause="6.2.8" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-1:2008" clause="8.9.5.1, Table 89"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_2" clause="6.2.8.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-2B.xml
+++ b/PDF_A/PDFA-2B.xml
@@ -639,6 +639,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_2" clause="6.2.8" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-1:2008" clause="8.9.5.1, Table 89"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_2" clause="6.2.8.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-2U.xml
+++ b/PDF_A/PDFA-2U.xml
@@ -639,6 +639,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_2" clause="6.2.8" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-1:2008" clause="8.9.5.1, Table 89"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_2" clause="6.2.8.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-3A.xml
+++ b/PDF_A/PDFA-3A.xml
@@ -639,6 +639,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_3" clause="6.2.8" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-1:2008" clause="8.9.5.1, Table 89"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_3" clause="6.2.8.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-3B.xml
+++ b/PDF_A/PDFA-3B.xml
@@ -639,6 +639,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_3" clause="6.2.8" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-1:2008" clause="8.9.5.1, Table 89"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_3" clause="6.2.8.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-3U.xml
+++ b/PDF_A/PDFA-3U.xml
@@ -639,6 +639,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_3" clause="6.2.8" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-1:2008" clause="8.9.5.1, Table 89"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_3" clause="6.2.8.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-4.xml
+++ b/PDF_A/PDFA-4.xml
@@ -558,6 +558,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_4" clause="6.2.7.1" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-2:2020" clause="8.9.5.1, Table 87"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_4" clause="6.2.7.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-4E.xml
+++ b/PDF_A/PDFA-4E.xml
@@ -572,6 +572,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_4" clause="6.2.7.1" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-2:2020" clause="8.9.5.1, Table 87"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_4" clause="6.2.7.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>

--- a/PDF_A/PDFA-4F.xml
+++ b/PDF_A/PDFA-4F.xml
@@ -558,6 +558,21 @@
             </error>
             <references/>
         </rule>
+        <rule object="PDXImage">
+            <id specification="ISO_19005_4" clause="6.2.7.1" testNumber="4"/>
+            <description>If an Image dictionary contains the BitsPerComponent key, its value shall be 1, 2, 4, 8 or 16</description>
+            <test>BitsPerComponent == null || BitsPerComponent == 1 || BitsPerComponent == 2 || BitsPerComponent == 4 ||
+                BitsPerComponent == 8 || BitsPerComponent == 16</test>
+            <error>
+                <message>The value of the BitsPerComponent key in the Image dictionary is %1</message>
+                <arguments>
+                    <argument>BitsPerComponent</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-2:2020" clause="8.9.5.1, Table 87"/>
+            </references>
+        </rule>
         <rule object="JPEG2000">
             <id specification="ISO_19005_4" clause="6.2.7.3" testNumber="1"/>
             <description>The number of colour channels in the JPEG2000 data shall be 1, 3 or 4.</description>


### PR DESCRIPTION
6.2.4-4(PDF/A-1),6.2.8-4(PDF/A-2,3),6.2.7.1-4(PDF/A-4)