### PR TITLE
Update tagged profile

### DIFF
--- a/PDF_UA/ISO-32005-Tagged.xml
+++ b/PDF_UA/ISO-32005-Tagged.xml
@@ -178,18 +178,6 @@
                 <reference specification="ISO-32000-2" clause="Annex_L"/>
             </references>
         </rule>
-        <rule object="SEPrivate" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Annot-Private" testNumber="1"/>
-            <description>&lt;Annot&gt; shall not contain &lt;Private&gt;</description>
-            <test>parentStandardType != 'Annot'</test>
-            <error>
-                <message>&lt;Annot&gt; contains &lt;Private&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
         <rule object="SERB" tags="structure">
             <id specification="ISO_32005" clause="Table 5. Annot-RB" testNumber="1"/>
             <description>&lt;Annot&gt; shall not contain &lt;RB&gt;</description>
@@ -364,6 +352,18 @@
             <test>parentStandardType != 'Art'</test>
             <error>
                 <message>&lt;Art&gt; contains &lt;BibEntry&gt;</message>
+                <arguments/>
+            </error>
+            <references>
+                <reference specification="ISO-32000-2" clause="Annex_L"/>
+            </references>
+        </rule>
+        <rule object="SEArt" tags="structure,caption">
+            <id specification="ISO_32005" clause="Table 5. Art-Caption" testNumber="1"/>
+            <description>&lt;Art&gt; shall contain at most one &lt;Caption&gt;</description>
+            <test>kidsStandardTypes.split('&amp;').filter(elem =&gt; elem == 'Caption').length &lt;= 1</test>
+            <error>
+                <message>&lt;Art&gt; contains more than one &lt;Caption&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -1978,60 +1978,12 @@
                 <reference specification="ISO-32000-2" clause="Annex_L"/>
             </references>
         </rule>
-        <rule object="SEArt" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Art" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Art&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Art&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEAside" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Aside" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Aside&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Aside&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEBlockQuote" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-BlockQuote" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;BlockQuote&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;BlockQuote&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SECaption" tags="structure,caption">
+        <rule object="SECode" tags="structure,caption">
             <id specification="ISO_32005" clause="Table 5. Code-Caption" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Caption&gt;</description>
-            <test>parentStandardType != 'Code'</test>
+            <description>&lt;Code&gt; shall contain at most one &lt;Caption&gt;</description>
+            <test>kidsStandardTypes.split('&amp;').filter(elem =&gt; elem == 'Caption').length &lt;= 1</test>
             <error>
-                <message>&lt;Code&gt; contains &lt;Caption&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SECode" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Code" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Code&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Code&gt;</message>
+                <message>&lt;Code&gt; contains more than one &lt;Caption&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -2044,42 +1996,6 @@
             <test>parentStandardType != 'Code'</test>
             <error>
                 <message>&lt;Code&gt; contains &lt;Document&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEFigure" tags="structure,figure">
-            <id specification="ISO_32005" clause="Table 5. Code-Figure" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Figure&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Figure&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEForm" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Form" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Form&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Form&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEFormula" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Formula" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Formula&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Formula&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -2110,30 +2026,6 @@
                 <reference specification="ISO-32000-2" clause="Annex_L"/>
             </references>
         </rule>
-        <rule object="SEIndex" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Index" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Index&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Index&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEL" tags="structure,list">
-            <id specification="ISO_32005" clause="Table 5. Code-L" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;L&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;L&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
         <rule object="SELBody" tags="structure,list">
             <id specification="ISO_32005" clause="Table 5. Code-LBody" testNumber="1"/>
             <description>&lt;Code&gt; shall not contain &lt;LBody&gt;</description>
@@ -2152,42 +2044,6 @@
             <test>parentStandardType != 'Code'</test>
             <error>
                 <message>&lt;Code&gt; contains &lt;LI&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SELbl" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Lbl" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Lbl&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Lbl&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEP" tags="structure,paragraph">
-            <id specification="ISO_32005" clause="Table 5. Code-P" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;P&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;P&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEQuote" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Quote" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Quote&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Quote&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -2224,30 +2080,6 @@
             <test>parentStandardType != 'Code'</test>
             <error>
                 <message>&lt;Code&gt; contains &lt;RT&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SERuby" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Ruby" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Ruby&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Ruby&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SESect" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Sect" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Sect&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Sect&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -2350,18 +2182,6 @@
                 <reference specification="ISO-32000-2" clause="Annex_L"/>
             </references>
         </rule>
-        <rule object="SETable" tags="structure,table">
-            <id specification="ISO_32005" clause="Table 5. Code-Table" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Table&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Table&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
         <rule object="SETitle" tags="structure">
             <id specification="ISO_32005" clause="Table 5. Code-Title" testNumber="1"/>
             <description>&lt;Code&gt; shall not contain &lt;Title&gt;</description>
@@ -2392,18 +2212,6 @@
             <test>parentStandardType != 'Code'</test>
             <error>
                 <message>&lt;Code&gt; contains &lt;WT&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEWarichu" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Code-Warichu" testNumber="1"/>
-            <description>&lt;Code&gt; shall not contain &lt;Warichu&gt;</description>
-            <test>parentStandardType != 'Code'</test>
-            <error>
-                <message>&lt;Code&gt; contains &lt;Warichu&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -3430,18 +3238,6 @@
                 <reference specification="ISO-32000-2" clause="Annex_L"/>
             </references>
         </rule>
-        <rule object="SEBibEntry" tags="structure,note">
-            <id specification="ISO_32005" clause="Table 5. FENote-BibEntry" testNumber="1"/>
-            <description>&lt;FENote&gt; shall not contain &lt;BibEntry&gt;</description>
-            <test>parentStandardType != 'FENote'</test>
-            <error>
-                <message>&lt;FENote&gt; contains &lt;BibEntry&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
         <rule object="SEDocument" tags="structure,note">
             <id specification="ISO_32005" clause="Table 5. FENote-Document" testNumber="1"/>
             <description>&lt;FENote&gt; shall not contain &lt;Document&gt;</description>
@@ -3472,18 +3268,6 @@
             <test>parentStandardType != 'FENote'</test>
             <error>
                 <message>&lt;FENote&gt; contains &lt;Hn&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEIndex" tags="structure,note">
-            <id specification="ISO_32005" clause="Table 5. FENote-Index" testNumber="1"/>
-            <description>&lt;FENote&gt; shall not contain &lt;Index&gt;</description>
-            <test>parentStandardType != 'FENote'</test>
-            <error>
-                <message>&lt;FENote&gt; contains &lt;Index&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -4630,12 +4414,12 @@
                 <reference specification="ISO-32000-2" clause="Annex_L"/>
             </references>
         </rule>
-        <rule object="SEH" tags="structure,heading">
+        <rule object="SEArt" tags="structure,heading">
             <id specification="ISO_32005" clause="Table 5. H-Art" testNumber="1"/>
-            <description>&lt;H&gt; shall contain at most one &lt;Art&gt;</description>
-            <test>kidsStandardTypes.split('&amp;').filter(elem =&gt; elem == 'Art').length &lt;= 1</test>
+            <description>&lt;H&gt; shall not contain &lt;Art&gt;</description>
+            <test>parentStandardType != 'H'</test>
             <error>
-                <message>&lt;H&gt; contains more than one &lt;Art&gt;</message>
+                <message>&lt;H&gt; contains &lt;Art&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -5002,12 +4786,12 @@
                 <reference specification="ISO-32000-2" clause="Annex_L"/>
             </references>
         </rule>
-        <rule object="SEHn" tags="structure">
+        <rule object="SEArt" tags="structure">
             <id specification="ISO_32005" clause="Table 5. Hn-Art" testNumber="1"/>
-            <description>&lt;Hn&gt; shall contain at most one &lt;Art&gt;</description>
-            <test>kidsStandardTypes.split('&amp;').filter(elem =&gt; elem == 'Art').length &lt;= 1</test>
+            <description>&lt;Hn&gt; shall not contain &lt;Art&gt;</description>
+            <test>/^H[1-9][0-9]*$/.test(parentStandardType) == false</test>
             <error>
-                <message>&lt;Hn&gt; contains more than one &lt;Art&gt;</message>
+                <message>&lt;Hn&gt; contains &lt;Art&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -5416,6 +5200,18 @@
             <test>parentStandardType != 'Index'</test>
             <error>
                 <message>&lt;Index&gt; contains &lt;BlockQuote&gt;</message>
+                <arguments/>
+            </error>
+            <references>
+                <reference specification="ISO-32000-2" clause="Annex_L"/>
+            </references>
+        </rule>
+        <rule object="SEIndex" tags="structure,caption">
+            <id specification="ISO_32005" clause="Table 5. Index-Caption" testNumber="1"/>
+            <description>&lt;Index&gt; shall contain at most one &lt;Caption&gt;</description>
+            <test>kidsStandardTypes.split('&amp;').filter(elem =&gt; elem == 'Caption').length &lt;= 1</test>
+            <error>
+                <message>&lt;Index&gt; contains more than one &lt;Caption&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -7768,6 +7564,18 @@
             <test>parentStandardType != 'Link'</test>
             <error>
                 <message>&lt;Link&gt; contains &lt;WT&gt;</message>
+                <arguments/>
+            </error>
+            <references>
+                <reference specification="ISO-32000-2" clause="Annex_L"/>
+            </references>
+        </rule>
+        <rule object="SENote" tags="structure,caption,note">
+            <id specification="ISO_32005" clause="Table 5. Note-Caption" testNumber="1"/>
+            <description>&lt;Note&gt; shall contain at most one &lt;Caption&gt;</description>
+            <test>kidsStandardTypes.split('&amp;').filter(elem =&gt; elem == 'Caption').length &lt;= 1</test>
+            <error>
+                <message>&lt;Note&gt; contains more than one &lt;Caption&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -10264,18 +10072,6 @@
             <test>parentStandardType != 'Reference'</test>
             <error>
                 <message>&lt;Reference&gt; contains &lt;Form&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEFormula" tags="structure">
-            <id specification="ISO_32005" clause="Table 5. Reference-Formula" testNumber="1"/>
-            <description>&lt;Reference&gt; shall not contain &lt;Formula&gt;</description>
-            <test>parentStandardType != 'Reference'</test>
-            <error>
-                <message>&lt;Reference&gt; contains &lt;Formula&gt;</message>
                 <arguments/>
             </error>
             <references>
@@ -15892,18 +15688,6 @@
             <test>parentStandardType != 'TOC'</test>
             <error>
                 <message>&lt;TOC&gt; contains &lt;P&gt;</message>
-                <arguments/>
-            </error>
-            <references>
-                <reference specification="ISO-32000-2" clause="Annex_L"/>
-            </references>
-        </rule>
-        <rule object="SEPart" tags="structure,toc">
-            <id specification="ISO_32005" clause="Table 5. TOC-Part" testNumber="1"/>
-            <description>&lt;TOC&gt; shall not contain &lt;Part&gt;</description>
-            <test>parentStandardType != 'TOC'</test>
-            <error>
-                <message>&lt;TOC&gt; contains &lt;Part&gt;</message>
                 <arguments/>
             </error>
             <references>


### PR DESCRIPTION
- Disabled rules:
&lt;Annot&gt; shall not contain &lt;Private&gt;
&lt;Code&gt; shall not contain &lt;Art&gt;
&lt;Code&gt; shall not contain &lt;Aside&gt;
&lt;Code&gt; shall not contain &lt;BlockQuote&gt;
&lt;Code&gt; shall not contain &lt;Figure&gt;
&lt;Code&gt; shall not contain &lt;Form&gt;
&lt;Code&gt; shall not contain &lt;Formula&gt;
&lt;Code&gt; shall not contain &lt;Index&gt;
&lt;Code&gt; shall not contain &lt;L&gt;
&lt;Code&gt; shall not contain &lt;Lbl&gt;
&lt;Code&gt; shall not contain &lt;P&gt;
&lt;Code&gt; shall not contain &lt;Quote&gt;
&lt;Code&gt; shall not contain &lt;Ruby&gt;
&lt;Code&gt; shall not contain &lt;Sect&gt;
&lt;Code&gt; shall not contain &lt;Table&gt;
&lt;Code&gt; shall not contain &lt;Warichu&gt;
&lt;FENote&gt; shall not contain &lt;BibEntry&gt;
&lt;FENote&gt; shall not contain &lt;Index&gt;
&lt;Reference&gt; shall not contain &lt;Formula&gt;
&lt;TOC&gt; shall not contain &lt;Part&gt;

- New rules:
&lt;Art&gt; shall contain at most one &lt;Caption&gt;
&lt;Index&gt; shall contain at most one &lt;Caption&gt;
&lt;Note&gt; shall contain at most one &lt;Caption&gt;

- Changed rules:
&lt;Code&gt; shall not contain &lt;Caption&gt; -> &lt;Code&gt; shall contain at most one &lt;Caption&gt;
&lt;H&gt; shall contain at most one &lt;Art&gt; -> &lt;H&gt; shall not contain &lt;Art&gt;
&lt;Hn&gt; shall contain at most one &lt;Art&gt; -> &lt;Hn&gt; shall not contain &lt;Art&gt;
