### PR TITLE
Change rev value requirement to specific year

### DIFF
--- a/PDF_A/4/6.7 Metadata/6.7.3 Version identification/verapdf-profile-6-7-3-t05.xml
+++ b/PDF_A/4/6.7 Metadata/6.7.3 Version identification/verapdf-profile-6-7-3-t05.xml
@@ -8,10 +8,10 @@
     <rules>
         <rule object="PDFAIdentification">
             <id specification="ISO_19005_4" clause="6.7.3" testNumber="5"/>
-            <description>The value of &quot;pdfaid:rev&quot; shall be the four digit year</description>
-            <test>/^\d{4}$/.test(rev)</test>
+            <description>The value of &quot;pdfaid:rev&quot; shall be &quot;2020&quot;</description>
+            <test>rev == &quot;2020&quot;</test>
             <error>
-                <message>The value of &quot;pdfaid:rev&quot; (%1) is not the four digit year</message>
+                <message>The value of &quot;pdfaid:rev&quot; (%1) is not &quot;2020&quot;</message>
                 <arguments>
                     <argument>rev</argument>
                 </arguments>

--- a/PDF_UA/2/5 Version identification/verapdf-profile-5-t05.xml
+++ b/PDF_UA/2/5 Version identification/verapdf-profile-5-t05.xml
@@ -8,10 +8,10 @@
     <rules>
         <rule object="PDFUAIdentification" tags="minor,machine,metadata">
             <id specification="ISO_14289_2" clause="5" testNumber="5"/>
-            <description>The value of &quot;pdfuaid:rev&quot; shall be the four digit year</description>
-            <test>/^\d{4}$/.test(rev)</test>
+            <description>The value of &quot;pdfuaid:rev&quot; shall be &quot;2024&quot;</description>
+            <test>rev == &quot;2024&quot;</test>
             <error>
-                <message>The value of &quot;pdfuaid:rev&quot; (%1) is not the four digit year</message>
+                <message>The value of &quot;pdfuaid:rev&quot; (%1) is not &quot;2024&quot;</message>
                 <arguments>
                     <argument>rev</argument>
                 </arguments>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PDF/A validation rule to require revision year value of "2020" instead of accepting any four-digit year.
  * Updated PDF/UA validation rule to require revision year value of "2024" instead of accepting any four-digit year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->