### PR TITLE
Update rules messages

### DIFF
--- a/PDF_A/2a/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
+++ b/PDF_A/2a/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
@@ -13,7 +13,7 @@
                 &quot;pdfaid:conformance&quot; as B. A Level U conforming file shall specify the value of &quot;pdfaid:conformance&quot; as U</description>
             <test>conformance == &quot;A&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;A&quot; for PDF/A-2A conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;A&quot; for PDF/A-2a conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/2b/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
+++ b/PDF_A/2b/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
@@ -13,7 +13,7 @@
                 &quot;pdfaid:conformance&quot; as B. A Level U conforming file shall specify the value of &quot;pdfaid:conformance&quot; as U</description>
             <test>conformance == &quot;B&quot; || conformance == &quot;U&quot; || conformance == &quot;A&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;B&quot; for PDF/A-2B conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;B&quot; for PDF/A-2b conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/2u/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
+++ b/PDF_A/2u/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
@@ -13,7 +13,7 @@
                 &quot;pdfaid:conformance&quot; as B. A Level U conforming file shall specify the value of &quot;pdfaid:conformance&quot; as U</description>
             <test>conformance == &quot;U&quot; || conformance == &quot;A&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;U&quot; for PDF/A-2U conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;U&quot; for PDF/A-2u conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/3a/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
+++ b/PDF_A/3a/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
@@ -13,7 +13,7 @@
                 &quot;pdfaid:conformance&quot; as B. A Level U conforming file shall specify the value of &quot;pdfaid:conformance&quot; as U</description>
             <test>conformance == &quot;A&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;A&quot; for PDF/A-3A conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;A&quot; for PDF/A-3a conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/3b/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
+++ b/PDF_A/3b/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
@@ -13,7 +13,7 @@
 			pdfaid:conformance as B. A Level U conforming file shall specify the value of pdfaid:conformance as U</description>
             <test>conformance == &quot;B&quot; || conformance == &quot;U&quot; || conformance == &quot;A&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;B&quot; for PDF/A-3B conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;B&quot; for PDF/A-3b conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/3u/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
+++ b/PDF_A/3u/6.6 Metadata/6.6.4 Version and conformance level identification/verapdf-profile-6-6-4-t03.xml
@@ -13,7 +13,7 @@
                 &quot;pdfaid:conformance&quot; as B. A Level U conforming file shall specify the value of &quot;pdfaid:conformance&quot; as U</description>
             <test>conformance == &quot;U&quot; || conformance == &quot;A&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;U&quot; for PDF/A-3U conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;U&quot; for PDF/A-3u conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/4e/6.7.3 Version identification/verapdf-profile-6-7-3-t03.xml
+++ b/PDF_A/4e/6.7.3 Version identification/verapdf-profile-6-7-3-t03.xml
@@ -11,7 +11,7 @@
             <description>A PDF/A-4e conforming file (as described in Annex B) shall specify the value of &quot;pdfaid:conformance&quot; as E</description>
             <test>conformance == &quot;E&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;E&quot; for PDF/A-4E conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;E&quot; for PDF/A-4e conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/4f/6.7.3 Version identification/verapdf-profile-6-7-3-t03.xml
+++ b/PDF_A/4f/6.7.3 Version identification/verapdf-profile-6-7-3-t03.xml
@@ -11,7 +11,7 @@
             <description>A PDF/A-4f conforming file (as described in Annex A) shall specify the value of &quot;pdfaid:conformance&quot; as F</description>
             <test>conformance == &quot;F&quot;</test>
             <error>
-                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;F&quot; for PDF/A-4F conforming file</message>
+                <message>The &quot;conformance&quot; property of the PDF/A Identification Schema is %1 instead of &quot;F&quot; for PDF/A-4f conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-2A.xml
+++ b/PDF_A/PDFA-2A.xml
@@ -1646,7 +1646,7 @@
             <description>A Level A conforming file shall specify the value of "pdfaid:conformance" as A. A Level B conforming file shall specify the value of "pdfaid:conformance" as B. A Level U conforming file shall specify the value of "pdfaid:conformance" as U</description>
             <test>conformance == "A"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "A" for PDF/A-2A conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "A" for PDF/A-2a conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-2B.xml
+++ b/PDF_A/PDFA-2B.xml
@@ -1612,7 +1612,7 @@
             <description>A Level A conforming file shall specify the value of "pdfaid:conformance" as A. A Level B conforming file shall specify the value of "pdfaid:conformance" as B. A Level U conforming file shall specify the value of "pdfaid:conformance" as U</description>
             <test>conformance == "B" || conformance == "U" || conformance == "A"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "B" for PDF/A-2B conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "B" for PDF/A-2b conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-2U.xml
+++ b/PDF_A/PDFA-2U.xml
@@ -1634,7 +1634,7 @@
             <description>A Level A conforming file shall specify the value of "pdfaid:conformance" as A. A Level B conforming file shall specify the value of "pdfaid:conformance" as B. A Level U conforming file shall specify the value of "pdfaid:conformance" as U</description>
             <test>conformance == "U" || conformance == "A"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "U" for PDF/A-2U conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "U" for PDF/A-2u conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-3A.xml
+++ b/PDF_A/PDFA-3A.xml
@@ -1646,7 +1646,7 @@
             <description>A Level A conforming file shall specify the value of "pdfaid:conformance" as A. A Level B conforming file shall specify the value of "pdfaid:conformance" as B. A Level U conforming file shall specify the value of "pdfaid:conformance" as U</description>
             <test>conformance == "A"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "A" for PDF/A-3A conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "A" for PDF/A-3a conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-3B.xml
+++ b/PDF_A/PDFA-3B.xml
@@ -1612,7 +1612,7 @@
             <description>A Level A conforming file shall specify the value of pdfaid:conformance as A. A Level B conforming file shall specify the value of pdfaid:conformance as B. A Level U conforming file shall specify the value of pdfaid:conformance as U</description>
             <test>conformance == "B" || conformance == "U" || conformance == "A"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "B" for PDF/A-3B conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "B" for PDF/A-3b conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-3U.xml
+++ b/PDF_A/PDFA-3U.xml
@@ -1634,7 +1634,7 @@
             <description>A Level A conforming file shall specify the value of "pdfaid:conformance" as A. A Level B conforming file shall specify the value of "pdfaid:conformance" as B. A Level U conforming file shall specify the value of "pdfaid:conformance" as U</description>
             <test>conformance == "U" || conformance == "A"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "U" for PDF/A-3U conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "U" for PDF/A-3u conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-4E.xml
+++ b/PDF_A/PDFA-4E.xml
@@ -1189,7 +1189,7 @@
             <description>A PDF/A-4e conforming file (as described in Annex B) shall specify the value of "pdfaid:conformance" as E</description>
             <test>conformance == "E"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "E" for PDF/A-4E conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "E" for PDF/A-4e conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>

--- a/PDF_A/PDFA-4F.xml
+++ b/PDF_A/PDFA-4F.xml
@@ -1175,7 +1175,7 @@
             <description>A PDF/A-4f conforming file (as described in Annex A) shall specify the value of "pdfaid:conformance" as F</description>
             <test>conformance == "F"</test>
             <error>
-                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "F" for PDF/A-4F conforming file</message>
+                <message>The "conformance" property of the PDF/A Identification Schema is %1 instead of "F" for PDF/A-4f conforming file</message>
                 <arguments>
                     <argument>conformance</argument>
                 </arguments>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  - Updated PDF/A conformance level labels in validation error messages to standardize formatting across all profiles, changing from uppercase to lowercase notation (e.g., "PDF/A-2a" instead of "PDF/A-2A", "PDF/A-3b" instead of "PDF/A-3B") for consistent user-facing error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->