### PR TITLE
update H+Hn tags message

### DIFF
--- a/PDF_UA/PDFUA-1.xml
+++ b/PDF_UA/PDFUA-1.xml
@@ -803,7 +803,7 @@
             <description>All documents shall be either strongly or weakly structured, but not both</description>
             <test>usesHn == false</test>
             <error>
-                <message>Document uses both H and H# tags</message>
+                <message>Document uses H tag in presence of Hn tags</message>
                 <arguments/>
             </error>
             <references/>
@@ -813,7 +813,7 @@
             <description>All documents shall be either strongly or weakly structured, but not both</description>
             <test>usesH == false</test>
             <error>
-                <message>Document uses both H and H# tags</message>
+                <message>Document uses Hn tags in presence of H tags</message>
                 <arguments/>
             </error>
             <references/>


### PR DESCRIPTION
update H/Hn error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message clarity for PDF accessibility validation. Heading structure error messages now provide more precise guidance when H and Hn tags are incorrectly mixed, helping users resolve accessibility issues faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->