### PR TITLE
Add support for PDF/A-4 rule 6.1.9-2

### DIFF
--- a/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t01.xml
+++ b/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t01.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_4">
     <details creator="veraPDF Consortium" created="2020-12-15T10:58:07.177+03:00">
-        <name>ISO 19005-4:2020 - 6.1.9 Inline image dictionaries</name>
+        <name>ISO 19005-4:2020 - 6.1.9 Inline image dictionaries - Filters</name>
         <description>The value of the F key in the Inline Image dictionary shall not be LZW, LZWDecode, Crypt, a value not listed in ISO 32000-2:2020, 8.9.7, Table 92,
 	    or an array containing any such value</description>
     </details>

--- a/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t02.xml
+++ b/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t02.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_4">
+    <details creator="veraPDF Consortium" created="2020-12-15T10:58:07.177+03:00">
+        <name>ISO 19005-4:2020 - 6.1.9 Inline image dictionaries</name>
+        <description>Any inline image dictionary shall contain a L key whose value is the length of the data as it appears in the stream, before applying the filters, if any.</description>
+    </details>
+    <hash></hash>
+    <rules>
+        <rule object="PDInlineImage">
+            <id specification="ISO_19005_4" clause="6.1.9" testNumber="2"/>
+            <description>Any inline image dictionary shall contain a L key whose value is the length of the data as it appears in the stream, before applying the filters, if any.</description>
+            <test>
+                L == streamLength</test>
+            <error>
+                <message>The value of the L key %1 in the inline image dictionary does not represent actual length of the data %2</message>
+                <arguments>
+                    <argument>L</argument>
+                    <argument>streamLength</argument>
+                </arguments>
+            </error>
+            <references>
+                <reference specification="ISO 32000-2:2020" clause="8.9.7"/>
+            </references>
+        </rule>
+    </rules>
+    <variables/>
+</profile>

--- a/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t02.xml
+++ b/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t02.xml
@@ -18,9 +18,6 @@
                     <argument>streamLength</argument>
                 </arguments>
             </error>
-            <references>
-                <reference specification="ISO 32000-2:2020" clause="8.9.7"/>
-            </references>
         </rule>
     </rules>
     <variables/>

--- a/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t02.xml
+++ b/PDF_A/4/6.1 File structure/6.1.9 Inline image dictionaries/verapdf-profile-6-1-9-t02.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_4">
     <details creator="veraPDF Consortium" created="2020-12-15T10:58:07.177+03:00">
-        <name>ISO 19005-4:2020 - 6.1.9 Inline image dictionaries</name>
+        <name>ISO 19005-4:2020 - 6.1.9 Inline image dictionaries - Correct Length</name>
         <description>Any inline image dictionary shall contain a L key whose value is the length of the data as it appears in the stream, before applying the filters, if any.</description>
     </details>
     <hash></hash>
@@ -18,6 +18,7 @@
                     <argument>streamLength</argument>
                 </arguments>
             </error>
+            <references/>
         </rule>
     </rules>
     <variables/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new veraPDF validation profile for PDF/A-4 clause 6.1.9 (“Inline image dictionaries”).
  * Inline image dictionary length is now verified to match the corresponding stream length.
  * Validation errors report the declared versus actual lengths.
* **Documentation**
  * Updated the profile’s displayed details label for the “Filters” variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->