### PR TITLE
PDF/A-4. Add rule 6.2.3-4

### DIFF
--- a/PDF_A/4/6.2 Graphics/6.2.3 Output intent/verapdf-profile-6-2-3-t04.xml
+++ b/PDF_A/4/6.2 Graphics/6.2.3 Output intent/verapdf-profile-6-2-3-t04.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_4">
+    <details creator="veraPDF Consortium" created="2020-12-15T10:58:08.302+03:00">
+        <name>ISO 19005-4:2020 - 6.2.3 Output intent - PDF/A Output Intents</name>
+        <description>OutputIntents array shall contain at most one PDF/A output intent</description>
+    </details>
+    <hash></hash>
+    <rules>
+        <rule object="OutputIntents">
+            <id specification="ISO_19005_4" clause="6.2.3" testNumber="4"/>
+            <description>OutputIntents array shall contain at most one PDF/A output intent</description>
+            <test>numberOfPDFAOutputIntents &lt;= 1</test>
+            <error>
+                <message>OutputIntents array contains %1 PDF/A output intents</message>
+                <arguments>
+                    <argument>numberOfPDFAOutputIntents</argument>
+                </arguments>
+            </error>
+            <references/>
+        </rule>
+    </rules>
+    <variables/>
+</profile>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a VeraPDF validation profile for PDF/A-4 output intents.
  * Validates that documents contain no more than one PDF/A output intent and reports an error with the actual count when this rule is violated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->